### PR TITLE
Use os.tmpdir to store vbs script files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ node_modules
 # see https://github.com/substack/browserify-handbook#organizing-modules
 node_modules/*
 !node_modules/app
+
+.idea/

--- a/index.js
+++ b/index.js
@@ -334,39 +334,40 @@ function toCommandArgs(cmd, arch, keys) {
 
     return result
 }
-var fs = require('fs');
-var tempVsdDir = path.join(os.tmpdir(), 'node-regedit');
+var fs = require('fs')
+var tempVsdDir = path.join(os.tmpdir(), 'node-regedit')
 
-copyVbsScriptToTemp = (function(){
-  var moved = false;
+var copyVbsScriptToTemp = (function(){
+    var moved = false
   
-  var vbsLocation = path.join(__dirname, 'vbs');
+    var vbsLocation = path.join(__dirname, 'vbs')
 
-  return function () {
-    if (moved) {
-      return
+    return function () {
+        if (moved) {
+            return
+        }
+        if (!fs.existsSync(tempVsdDir)) {
+            fs.mkdirSync(tempVsdDir)
+        }
+
+        var arr = fs.readdirSync(vbsLocation).filter(function(fileName){
+            var ext
+            return(ext = fileName.substr(-4)) === '.vbs' || ext === '.wsf'
+        })
+
+        console.log(arr, arr.length)
+
+        arr.forEach(function(c){
+            var content = fs.readFileSync(path.join(vbsLocation, c))
+            fs.writeFileSync(path.join(tempVsdDir, c), content)
+            console.log(path.join(tempVsdDir, c))
+        })
     }
-    if (!fs.existsSync(tempVsdDir)) {
-        fs.mkdirSync(tempVsdDir);
-    }
-
-    arr = fs.readdirSync(vbsLocation).filter(function(fileName){
-        return(ext = fileName.substr(-4)) === '.vbs' || ext === '.wsf'
-    })
-
-    console.log(arr, arr.length)
-
-    arr.map(function(c){
-        var content = fs.readFileSync(path.join(vbsLocation, c))
-        fs.writeFileSync(path.join(tempVsdDir, c), content);
-        console.log(path.join(tempVsdDir, c));
-    })
-  }
-})();
+}())
 
 //TODO: move to helper.js?
 function baseCommand(cmd, arch) {
-  copyVbsScriptToTemp();
-  return ['//Nologo', path.join(tempVsdDir, cmd), arch]
+    copyVbsScriptToTemp()
+    return ['//Nologo', path.join(tempVsdDir, cmd), arch]
 }
 

--- a/index.js
+++ b/index.js
@@ -334,8 +334,39 @@ function toCommandArgs(cmd, arch, keys) {
 
     return result
 }
+var fs = require('fs');
+var tempVsdDir = path.join(os.tmpdir(), 'node-regedit');
+
+copyVbsScriptToTemp = (function(){
+  var moved = false;
+  
+  var vbsLocation = path.join(__dirname, 'vbs');
+
+  return function () {
+    if (moved) {
+      return
+    }
+    if (!fs.existsSync(tempVsdDir)) {
+        fs.mkdirSync(tempVsdDir);
+    }
+
+    arr = fs.readdirSync(vbsLocation).filter(function(fileName){
+        return(ext = fileName.substr(-4)) === '.vbs' || ext === '.wsf'
+    })
+
+    console.log(arr, arr.length)
+
+    arr.map(function(c){
+        var content = fs.readFileSync(path.join(vbsLocation, c))
+        fs.writeFileSync(path.join(tempVsdDir, c), content);
+        console.log(path.join(tempVsdDir, c));
+    })
+  }
+})();
 
 //TODO: move to helper.js?
 function baseCommand(cmd, arch) {
-    return ['//Nologo', path.join(__dirname, 'vbs', cmd), arch]
+  copyVbsScriptToTemp();
+  return ['//Nologo', path.join(tempVsdDir, cmd), arch]
 }
+


### PR DESCRIPTION
I was using this npm package with Electron.
And due to electron's asar packed run time, legacy node-regedit fails due to cscript.exe cannot approach to VBS script files packed in app.asar in electron app.

So I added code to copy vbs scripts to OS's temporary dir.

And I also modified .gitignore file to ignore IDEA based IDE support
