### PR TITLE
fix: #102 unsupported hive caused by fix e2e40d for #48

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ function spawnEx(args, keys, callback) {
 
 		handleErrorsAndClose(child, callback)
 
-		helper.writeArrayToStream(keys, child.stdin)
+		helper.writeArrayToStream(keys.entries(), child.stdin)
 	})
 }
 
@@ -251,7 +251,7 @@ module.exports.list = function(keys, architecture, callback) {
 
 		child.stdout.pipe(slicer).pipe(outputStream)
 
-		helper.writeArrayToStream(keys, child.stdin)
+		helper.writeArrayToStream(keys.entries(), child.stdin)
 	})
 
 	return outputStream
@@ -320,11 +320,10 @@ module.exports.putValue = function(map, architecture, callback) {
 				if (keyValues.hasOwnProperty(valueName)) {
 					const entry = keyValues[valueName]
 
-					// helper writes the array to the stream in reversed order
-					values.push(entry.type)
-					values.push(renderValueByType(entry.value, entry.type))
-					values.push(valueName)
 					values.push(key)
+					values.push(valueName)
+					values.push(renderValueByType(entry.value, entry.type))
+					values.push(entry.type)
 				}
 			}
 		}
@@ -372,7 +371,7 @@ module.exports.listUnexpandedValues = function(valuePaths, architecture, callbac
 
 		child.stdout.pipe(slicer).pipe(outputStream)
 
-		helper.writeArrayToStream(valuePaths, child.stdin)
+		helper.writeArrayToStream(valuePaths.entries(), child.stdin)
 	})
 
 	return outputStream

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -9,21 +9,19 @@ module.exports.encode = function(str) {
  *	Write an array to a stream, taking backpressure into consideration
  */
 module.exports.writeArrayToStream = function(arr, stream, optionalCallback) {
-	var member = arr.pop()
+	var member = arr.next()
 
 	function write(m) {
-			var b = module.exports.encode(m)
-			debug(b)
-			return stream.write(b)
-
-		return false
+		var b = module.exports.encode(m)
+		debug(b)
+		return stream.write(b)
+	}
+	
+	while (!member.done && write(member.value[1])) {
+		member = arr.next()
 	}
 
-	while (write(member)) {
-		member = arr.pop()
-	}
-
-	if (arr.length === 0) {
+	if (member.done) {
 		stream.write(WIN_EOL, optionalCallback)
 		return
 	}


### PR DESCRIPTION
This issue was caused by the fix attempt in #48 which prevented the loop from finishing.

Using an index instead of pop allows to control array positioning even through drain event and allows undefined items in the array. Also prevents popping items from an array that could be reused in the caller.